### PR TITLE
🐛 Fix GitHub Pages deploy by running CI on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: package.json
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "preview": "ln -fs public testing-sites && http-server . -p 4200"
   },
   "private": true,
+  "engines": {
+    "node": "24"
+  },
   "dependencies": {},
   "devDependencies": {
     "@nx/js": "22.7.5",


### PR DESCRIPTION
## Problem

The GitHub Pages deploy has been failing since the Astro 6 upgrade (#11). The `@testing-sites/astro:build` step fails in CI with:

```
Node.js v20.20.2 is not supported by Astro!
```

Astro 6 dropped support for Node 20 and requires Node 22+. The deploy workflow was pinned to Node 20, so only the CI build failed while local builds (on a newer Node) succeeded.

## Fix

- Pin the Node version to **24** via `engines.node` in the root `package.json`
- Have the deploy workflow read it through `actions/setup-node`'s `node-version-file: package.json`, so the Node version has a single source of truth

## Verification

- `nx run-many -t build` succeeds for all 4 projects (next, nuxt, svelte-kit, astro)
- `engine-strict` is not enabled, so the engines field does not block local installs on other Node versions